### PR TITLE
add reference to win10 print to pdf option

### DIFF
--- a/markdown/statinf-generatePDF.md
+++ b/markdown/statinf-generatePDF.md
@@ -4,7 +4,7 @@ Students in the Johns Hopkins University Data Science Specialization often strug
 
 One can create a PDF suitable for submission for the course project in three different ways, including:
 
-1. Generate an HTML document with knitr, and then use a PDF printing tool like [CutePDF](http://cutepdf.com) to print the HTML document as a PDF,
+1. Generate an HTML document with knitr, and then use a PDF printing tool like the Windows 10 built-in "Microsoft Print to PDF" printer driver or [CutePDF](http://cutepdf.com) to print the HTML document as a PDF,
 2. Generate a Microsoft Word document with knitr, and print the Word document as a PDF using Word 2013+ PDF print driver, or
 3. Install a version of LaTeX that is appropriate for your operating system, and use knitr to directly generate PDF files.
 


### PR DESCRIPTION
Proposing minor update to include mention of windows 10 built-in print to pdf printer driver support.  

I might also suggest, although i did not include changes to capture it, that you revisit ability for folks to just install MikTex 2.9+ basic install and let it auto-install packages as needed.  I used this and it worked so not sure what issue was that has guidance pointing folks to doing the much more painful time and machine resources consuming full install.