### PR TITLE
adding more details and tests around accessing oob 

### DIFF
--- a/pml-exampleSonarRandomForest.R
+++ b/pml-exampleSonarRandomForest.R
@@ -46,16 +46,40 @@ system.time(fit <- train(Class ~ ., method="rf",data=Sonar,trControl = fitContro
 #
 stopCluster(cluster)
 registerDoSEQ()
+
 #
 # Step 5: evaluate model fit 
 #
 fit
 fit$resample
 confusionMatrix.train(fit)
-#average OOB error
-mean(fit$finalModel$err.rate[,"OOB"])
-
 plot(fit,main="Accuracy by Predictor Count")
-varImpPlot(fit$finalModel,
-           main="Variable Importance Plot: Random Forest")
+varImpPlot(fit$finalModel, main="Variable Importance Plot: Random Forest")
 
+#
+# Step 6: acquire in sample estimate of error, which is the model oob [out-of-bag] estimate of error 
+# rate ???, for comparison in subsequent step with out of sample estimate of error
+#
+fit$finalModel # see "OOB estimate of  error rate: ##.#%" value in output
+# look for column name for oob [out-of-bag] estimate of error rate
+mer <- fit$finalModel$err.rate; dimnames(mer)
+# compare average of $err.rate[, "OOB"] with model output oob estimate of error rate
+mean(fit$finalModel$err.rate[, "OOB"]) * 100
+# compare median of $err.rate[, "OOB"] with model output oob estimate of error rate
+median(fit$finalModel$err.rate[, "OOB"]) * 100
+# found mean of $err.rate[,"OOB"] > median of $err.rate[,"OOB"] > fit$finalModel output OOB value
+inSampleError <- median(fit$finalModel$err.rate[, "OOB"]) * 100
+
+#
+# Step 7. Calculate out of sample estime of error rate and compare with in sample estimate of error rate
+#
+pred <- predict(fit, newdata = testing)
+confmat <- confusionMatrix(pred, testing$Class)
+confmat$table; confmat$overall[["Accuracy"]]
+predAccuracy <- confmat$overall[["Accuracy"]]
+outOfSampleError <- (1 - predAccuracy) * 100 
+outOfSampleError; inSampleError
+# Here we are looking for out of sample estimate error rate to be worse than in sample estimate of 
+# error rate in order. This is to confirm that accuracy should be better in case of training data 
+# where we knew the outcome values vs the unseen training data where we in theory don't know the 
+# outcome values.


### PR DESCRIPTION
Adding more details and tests around accessing oob estimate of error rate and using that value as comparison for out of sample estimate of error.  

Objective being to highlight how accessing mean and median of that err.rate column data doesn't produce match for the model output listed value for oob.

Also added Step 7 to try and confirm, or highlight confusion i'm left with, as to whether or not model output oob estimate of error rate is in fact what we would consider the in sample estimate of error rate.  Also how that value can/should be compared and confirmed to land on right side of how we were instructed to calculate out of sample estimate of error rate.